### PR TITLE
MongoDB's url can be set via environment variable.

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -15,6 +15,7 @@ db.password= # if not exists, please leave it blank
 # or you can set the mongdb url for more complex needs the format is:
 # mongodb://myuser:mypass@localhost:40001,otherhost:40001/mydb
 # db.url=mongodb://root:root123@localhost:27017/leanote
+db.url=${MONGODB_URL}
 
 # You Must Change It !! About Security!!
 app.secret=V85ZzBeTnzpsHyjQX4zukbQ8qqtju9y2aDM55VWxAH9Qop19poekx3xkcDVvrD0y 


### PR DESCRIPTION
The purpose of this pull request is: i wanna deploy leanote using docker container tech.

I am going to run mongodb and leanote app in different container. The mongodb container expose 27017 port, and the leanote container will link to mongodb container. Mongodb's url will be injected into leanote container via environment variable.  so i hope that leanote app can get mongodb's url from environment variable.

Thx