### PR TITLE
移除 toc 中多余的外层ul和li标签

### DIFF
--- a/public/libs/md2html/md2html.js
+++ b/public/libs/md2html/md2html.js
@@ -234,7 +234,9 @@ listStr=addAnchors(listStr);listStr=listStr.replace(/\n{2,}(?=\\x03)/,"\n");list
 	            elementList.push(new TocElement(elt.tagName, createAnchor(elt), elt.textContent));
 	        });
 	        elementList = groupTags(elementList);
-	        return '<div class="toc">\n<ul>\n' + elementList.join("") + '</ul>\n</div>\n';
+			var result = elementList.join("");
+			result = result.replace('li', 'div class="toc"').replace('li$', 'div');
+            return result;
 	    }
 
 	    toc.convert = function(previewContentsElt) {


### PR DESCRIPTION
外层无用的ul和li标签会导致缩进过深，影响观感。