### PR TITLE
修改网页端博客文档导航无效的bug

### DIFF
--- a/public/blog/js/common.js
+++ b/public/blog/js/common.js
@@ -248,7 +248,7 @@ function genNav() {
 		var text = $(hs[i]).text(); 
 		var tagName = hs[i].tagName.toLowerCase();
 		// scrollTo在page.js中定义
-		titles += '<li class="nav-' + tagName + '"><a data-a="' + tagName + '-' + encodeURI(text)+'" onclick="scrollTo(this, \'' + tagName + '\', \'' + text + '\')">' + text + '</a></li>';
+		titles += '<li class="nav-' + tagName + '"><a data-a="' + tagName + '-' + encodeURI(text)+'" onclick="window.scrollTo(this, \'' + tagName + '\', \'' + text + '\')">' + text + '</a></li>';
 	}
 	titles += "</ul>";
 	$("#blogNavContent").html(titles);


### PR DESCRIPTION
修改：网页端博客文档导航无效的bug
我在mac上，chrome 62 发现这个问题。
a标签 onclick方法scrollTo如果不加上window, 在某些浏览器上不执行scrollTo方法，导致无法导航。